### PR TITLE
Add absolute path checks for keyFile, outputPath and contentPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var path = require('path');
 var join = path.join;
 var mkdirp = require('mkdirp');
-var pathIsAbsolute = require('path-is-absolute');
 var ChromeExtension = require('crx');
 
 function Plugin(options) {
@@ -19,9 +18,9 @@ function Plugin(options) {
 
   // setup paths
   this.context = path.dirname(module.parent.filename);
-  this.keyFile = pathIsAbsolute(this.options.keyFile) ? this.options.keyFile : join(this.context, this.options.keyFile);
-  this.outputPath = pathIsAbsolute(this.options.outputPath) ? this.options.outputPath : join(this.context, this.options.outputPath);
-  this.contentPath = pathIsAbsolute(this.options.contentPath) ? this.options.contentPath : join(this.context, this.options.contentPath);
+  this.keyFile = path.isAbsolute(this.options.keyFile) ? this.options.keyFile : join(this.context, this.options.keyFile);
+  this.outputPath = path.isAbsolute(this.options.outputPath) ? this.options.outputPath : join(this.context, this.options.outputPath);
+  this.contentPath = path.isAbsolute(this.options.contentPath) ? this.options.contentPath : join(this.context, this.options.contentPath);
 
   // set output info
   this.crxName = this.options.name + ".crx";

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var join = path.join;
 var mkdirp = require('mkdirp');
+var pathIsAbsolute = require('path-is-absolute');
 var ChromeExtension = require('crx');
 
 function Plugin(options) {
@@ -18,9 +19,9 @@ function Plugin(options) {
 
   // setup paths
   this.context = path.dirname(module.parent.filename);
-  this.keyFile = join(this.context, this.options.keyFile);
-  this.outputPath = join(this.context, this.options.outputPath);
-  this.contentPath = join(this.context, this.options.contentPath);
+  this.keyFile = pathIsAbsolute(this.options.keyFile) ? this.options.keyFile : join(this.context, this.options.keyFile);
+  this.outputPath = pathIsAbsolute(this.options.outputPath) ? this.options.outputPath : join(this.context, this.options.outputPath);
+  this.contentPath = pathIsAbsolute(this.options.contentPath) ? this.options.contentPath : join(this.context, this.options.contentPath);
 
   // set output info
   this.crxName = this.options.name + ".crx";

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "url": "https://github.com/johnagan/crx-webpack-plugin/issues"
   },
   "dependencies": {
-    "crx": "~3.0.2",
     "mkdirp": "~0.5.0",
-    "path-is-absolute": "^1.0.0"
+    "crx": "~3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   ],
   "repository": {
     "type": "git",
-    "url" : "https://github.com/johnagan/crx-webpack-plugin.git"
+    "url": "https://github.com/johnagan/crx-webpack-plugin.git"
   },
   "bugs": {
     "url": "https://github.com/johnagan/crx-webpack-plugin/issues"
   },
   "dependencies": {
+    "crx": "~3.0.2",
     "mkdirp": "~0.5.0",
-    "crx": "~3.0.2"
+    "path-is-absolute": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/johnagan/crx-webpack-plugin.git"
+    "url" : "https://github.com/johnagan/crx-webpack-plugin.git"
   },
   "bugs": {
     "url": "https://github.com/johnagan/crx-webpack-plugin/issues"


### PR DESCRIPTION
If we determine absolute paths for `keyFile`, `outputPath` and `contentPath` fields, then all will be broken.
This PR add ability to determine paths in absolute manner.
