### PR TITLE
Change writeFile to writeFileSync for Node 10+ compatibility issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ Plugin.prototype.package = function() {
       mkdirp(self.outputPath, function(err) {
         if (err) throw(err)
         var updateXML = self.crx.generateUpdateXML();
-        fs.writeFile(self.updateFile, updateXML);
-        fs.writeFile(self.crxFile, buffer);
+        fs.writeFileSync(self.updateFile, updateXML);
+        fs.writeFileSync(self.crxFile, buffer);
       });
     });
   });


### PR DESCRIPTION
In Node v10.0.0 
`fs.writeFile(file, data[, options], callback)`
> The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.

Related to #12
Consider change `writeFile` to `writeFileSync`